### PR TITLE
Update docs to reflect the rebranding changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ![image](https://hub.steampipe.io/images/plugins/turbot/steampipecloud-social-graphic.png)
 
-# Steampipe Cloud Plugin for Steampipe
+# Steampipe Cloud Plugin for Steampipe [DEPRECATED]
+
+This plugin has been deprecated and replaced by [Turbot Pipes plugin](https://hub.steampipe.io/plugins/turbot/pipes). This was part of our [renaming](https://turbot.com/blog/2023/07/introducing-turbot-guardrails-and-pipes) of Steampipe Cloud to Turbot Pipes.
 
 Use SQL to query workspaces, connections and more from Steampipe Cloud.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,9 @@ og_description: "Query Steampipe Cloud with SQL! Open source CLI. No DB required
 og_image: "/images/plugins/turbot/steampipecloud-social-graphic.png"
 ---
 
-# Steampipe Cloud + Steampipe
+# Steampipe Cloud + Steampipe [DEPRECATED]
+
+This plugin has been deprecated and replaced by [Turbot Pipes plugin](https://hub.steampipe.io/plugins/turbot/pipes). This was part of our [renaming](https://turbot.com/blog/2023/07/introducing-turbot-guardrails-and-pipes) of Steampipe Cloud to Turbot Pipes.
 
 [Steampipe Cloud](https://cloud.steampipe.io/) is a fully managed SaaS platform for hosting Steampipe instances.
 


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
